### PR TITLE
Use all the functionality of cmake_find_package generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,6 @@ project(dummy
 
 include(GNUInstallDirs)
 
-install(FILES dummy-config.cmake my-super-cmake-file.cmake
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-)
+#install(FILES dummy-config.cmake my-super-cmake-file.cmake
+#	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+#)

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,20 +6,18 @@ class DummyConan(ConanFile):
     version = "1.0"
     topics = ("cmake")
     generators = "cmake_find_package"
-    exports_sources = ["CMakeLists.txt", "dummy-config.cmake", "my-super-cmake-file.cmake"]
+    exports_sources = ["CMakeLists.txt"]
+    settings = "os", "arch", "compiler", "build_type"
 
-    def configure_cmake(self):
+    def _configure_cmake(self):
         cmake = CMake(self)
         cmake.configure()
-
         return cmake
 
     def build(self):
-        cmake = self.configure_cmake()
+        cmake = self._configure_cmake()
         cmake.build()
 
     def package(self):
-        cmake = self.configure_cmake()
-        cmake.install()
-
-
+        cmake = self._configure_cmake()
+        #cmake.install()

--- a/dummy-config.cmake
+++ b/dummy-config.cmake
@@ -1,4 +1,0 @@
-message("here: ${CMAKE_CURRENT_LIST_FILE}")
-
-set(dummy_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-message("dummy_MODULE_PATH ${dummy_MODULE_PATH}")

--- a/my-super-cmake-file.cmake
+++ b/my-super-cmake-file.cmake
@@ -1,6 +1,0 @@
-message("file: ${CMAKE_CURRENT_LIST_FILE}")
-
-macro(do_some_incredible_stuff)
-	message("print something very smart")
-	message("perform some incredible stuff")
-endmacro()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,7 +7,3 @@ project(test_dummy
 find_package(dummy REQUIRED)
 message("dummy_MODULE_PATH: ${dummy_MODULE_PATH}")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${dummy_MODULE_PATH})
-
-include(my-super-cmake-file)
-
-do_some_incredible_stuff()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -2,25 +2,14 @@ from conans import ConanFile, CMake
 
 
 class DummyTestConan(ConanFile):
-    settings = "os"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "cmake_find_package"
-    requires = "dummy/1.0@demo/testing"
-
-    def configure_cmake(self):
-        cmake = CMake(self)
-        cmake.configure()
-
-        return cmake
 
     def build(self):
         self.cmake = CMake(self)
-
         print("{}".format(self.cmake.command_line))
-
         self.cmake.configure()
         self.cmake.build()
 
-
     def test(self):
-        self.cmake.test()
-
+        pass


### PR DESCRIPTION
Example on how to use the cmake_find_package generator without packaging additional configuration files for CMake.

With this approach, you will be able to use find_library() even for those that are not built with CMake or that don't have proper FindXX.cmake or config files.